### PR TITLE
Added a view for users to update themselves and for admins to update a user

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from rest_framework.urls import path
 
-from .views import get_users, create_user, login, get_current_user, logout, delete_user
+from .views import get_users, create_user, login, get_current_user, logout, delete_user, update_user
 
 urlpatterns = [
     path('', get_users, name='Get All Users'),
@@ -9,4 +9,5 @@ urlpatterns = [
     path('logout/', logout, name='Logout'),
     path('delete/user', delete_user, name='Delete User'),
     path('get_current_user/', get_current_user, name='Get Current User'),
+    path('update', update_user, name='Update User'),
 ]


### PR DESCRIPTION
### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I added a route for users to be updated
### Changes
<!-- Describe the changes made in this pull request -->
- Added route PATCH "/users/update"
  - Auth headers must include `Bearer TOKEN`
  - Body must include at least "id", but can include all other user aspects too
  - "id" will not be updated, it is only used for finding the user to update
  - If "roles" is being updated and the requester isn't an admin, an error will be sent back
  - If "username" or "password" or both are being updated, the user's JWT will be revoked so they'll have to log in again
  - "password" will be rehashed when being saved to the database
  - Updated user information will be sent back, but should not be saved in the frontend until the user logs in again
### Screenshots (if applicable)
An example of if I wanted to update all of the user's attributes (as an admin)
![image](https://github.com/user-attachments/assets/8f42b120-fc0c-4645-9445-27a86ac6a028)
